### PR TITLE
Update the result reader to parse final statistics only

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,10 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
   <modelVersion>4.0.0</modelVersion>
   <parent>
-    <groupId>org.jvnet.hudson.plugins</groupId>
+    <groupId>org.jenkins-ci.plugins</groupId>
     <artifactId>plugin</artifactId>
-    <version>1.319</version>
-    <relativePath>../pom.xml</relativePath>
+    <version>1.420</version>
+    <relativePath/>
   </parent>
 
   <artifactId>grinder</artifactId>

--- a/src/main/java/hudson/plugins/grinder/ResultReader.java
+++ b/src/main/java/hudson/plugins/grinder/ResultReader.java
@@ -1,14 +1,14 @@
 package hudson.plugins.grinder;
 
-import org.apache.commons.io.IOUtils;
-
-import java.io.IOException;
+import java.io.BufferedReader;
 import java.io.InputStream;
+import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Scanner;
+import java.util.regex.Pattern;
 
 /**
  * Class used to read results from a Grinder output file.
@@ -21,6 +21,7 @@ public class ResultReader {
 
    private transient final PrintStream hudsonConsoleWriter;
 
+   private static final String PATTERN_STATS_HEADER = " Tests        Errors .*";
    private static final String PATTERN_TEST = "Test \\d.*";
    private static final String PATTERN_TOTALS = "Totals .*";
    private static final String PATTERN_TPS = " TPS ";
@@ -37,25 +38,42 @@ public class ResultReader {
       parse(is);
    }
 
+   /**
+    * Construct a result reader for grinder out log files.
+    *
+    * @param logger Logger to print messages to.
+    * @throws GrinderParseException Thrown if the parsing fails.
+    */
+   public ResultReader(PrintStream logger) {
+      hudsonConsoleWriter = logger;
+   }
+
    private void parse(InputStream is) {
       if (is == null) {
          throw new GrinderParseException("Empty input stream");
       }
+
       if (tests == null) {
          tests = new ArrayList<Test>();
       }
+
       try {
-         String str = IOUtils.toString(is);
+         BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(is));
+
+         String str = findStats(bufferedReader);
          boolean hasTPS = str.contains(PATTERN_TPS);
+
          Scanner scanner = new Scanner(str);
          String match = scanner.findWithinHorizon(PATTERN_TEST, 0);
+
+         boolean hasnext = scanner.hasNext();
          while (match != null) {
             tests.add(readTest(match, false, hasTPS));
             match = scanner.findWithinHorizon(PATTERN_TEST, 0);
          }
          match = scanner.findWithinHorizon(PATTERN_TOTALS, 0);
          totals = readTest(match, true, hasTPS);
-      } catch (IOException e) {
+      } catch (Exception e) {
          String errMsg = "Problem parsing Grinder out log file";
          hudsonConsoleWriter.println(errMsg + ": " + e.getMessage());
          e.printStackTrace(hudsonConsoleWriter);
@@ -91,8 +109,18 @@ public class ResultReader {
             scanner.next(); // reported as '?' in log
          }
          int respErrorCount = scanner.nextInt();
-         double resolveHostMeanTime = scanner.nextDouble();
-         double establishConnMeanTime = scanner.nextDouble();
+         double resolveHostMeanTime = 0.0;
+         if (scanner.hasNextDouble()) {
+            resolveHostMeanTime = scanner.nextDouble();
+         } else {
+            scanner.next(); // reported as '-' in log
+         }
+         double establishConnMeanTime = 0.0;
+         if (scanner.hasNextDouble()) {
+            establishConnMeanTime = scanner.nextDouble();
+         } else {
+            scanner.next(); // reported as '-' in log
+         }
          double firstByteMeanTime = Double.valueOf(scanner.next().replaceAll("[)]",""));
          String name = isTotals ? "" : scanner.next().replaceAll("\"", "");
 
@@ -124,4 +152,26 @@ public class ResultReader {
          );
       }
    }
+
+   private String findStats(BufferedReader bufferedReader) {
+      Scanner scanner = new Scanner(bufferedReader);
+      Pattern pattern = Pattern.compile(PATTERN_STATS_HEADER);
+      StringBuilder toBeReturned = new StringBuilder();
+      String line = scanner.findInLine(pattern);
+      while (line == null && scanner.hasNextLine()) {
+         scanner.nextLine();
+         line = scanner.findInLine(pattern);
+      }
+      hudsonConsoleWriter.println(line);
+      toBeReturned.append(line).append("\n");
+
+      while (scanner.hasNextLine()) {
+         String nextline = scanner.nextLine();
+         hudsonConsoleWriter.println(nextline);
+         toBeReturned.append(nextline).append("\n");
+      }
+
+      return toBeReturned.toString();
+   }
+
 }


### PR DESCRIPTION
This is the fix for the following issue
- Java heap space out of memory while creating string with Utils.toString from grinder log file (100MB+)
